### PR TITLE
Clean up the API for consistency

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -4,6 +4,7 @@
   :license {:name "The MIT License (MIT)"
             :url "http://opensource.org/licenses/MIT"
             :comments "Copyright (c) 2018 Unbounce Marketing Solutions Inc."}
+  :profiles {:dev {:dependencies [[org.clojure/test.check "0.9.0"]]}}
   :dependencies [[org.clojure/clojure "1.9.0"]
                  [com.datadoghq/java-dogstatsd-client "2.5"]]
   :global-vars {*warn-on-reflection* true})

--- a/src/com/unbounce/dogstatsd/core.clj
+++ b/src/com/unbounce/dogstatsd/core.clj
@@ -2,10 +2,11 @@
   (:import [com.timgroup.statsd StatsDClient NonBlockingStatsDClient ServiceCheck NoOpStatsDClient]))
 
 ;; In case setup! is not called, this prevents nullpointer exceptions i.e. Unit tests
-(defonce ^:private ^StatsDClient client
-  (NoOpStatsDClient.))
+(defonce ^:private ^StatsDClient client (NoOpStatsDClient.))
 
-(defn str-array [tags]
+(def ^:private ^"[Ljava.lang.String;" -empty-array (into-array String []))
+
+(defn ^"[Ljava.lang.String;" str-array [tags]
   (into-array String tags))
 
 (defn setup!
@@ -32,46 +33,58 @@
                                tags)))))
 
 (defn increment
-  [metric & {:keys [tags sample-rate]}]
-  (let [tags (str-array tags)]
-    (if sample-rate
-      (.incrementCounter client metric sample-rate tags)
-      (.incrementCounter client metric tags))))
+  ([metric]
+   (.incrementCounter client metric -empty-array))
+  ([metric {:keys [tags sample-rate]}]
+   (let [tags (str-array tags)]
+     (if sample-rate
+       (.incrementCounter client metric sample-rate tags)
+       (.incrementCounter client metric tags)))))
 
 (defn decrement
-  [metric & {:keys [tags sample-rate]}]
-  (let [tags (str-array tags)]
-  (if sample-rate
-    (.decrementCounter client metric sample-rate tags)
-    (.decrementCounter client metric tags))))
+  ([metric]
+   (.decrementCounter client metric -empty-array))
+  ([metric {:keys [tags sample-rate]}]
+   (let [tags (str-array tags)]
+     (if sample-rate
+       (.decrementCounter client metric sample-rate tags)
+       (.decrementCounter client metric tags)))))
 
 (defn gauge
-  [metric value {:keys [sample-rate tags]}]
-  (let [value       (double value)
-        tags        (str-array tags)
-        sample-rate (when sample-rate (double sample-rate))
-        f           (fn [^String metric ^double value {:keys [^double sample-rate #^"[Ljava.lang.String;" tags]}]
-                      (if sample-rate
-                        (.recordGaugeValue client metric value sample-rate tags)
-                        (.recordGaugeValue client metric value tags)))]
-    (f metric value {:sample-rate sample-rate
-                     :tags tags})))
+  ([^String metric ^Double value]
+   (.recordGaugeValue client metric value -empty-array))
+  ([^String metric ^Double value {:keys [sample-rate tags]}]
+   (let [tags        (str-array tags)
+         sample-rate ^Double sample-rate]
+     (if sample-rate
+       (.recordGaugeValue client metric value sample-rate tags)
+       (.recordGaugeValue client metric value tags)))))
 
 (defn histogram
-  [metric value {:keys [sample-rate tags]}]
-  (let [value       (double value)
-        tags        (str-array tags)
-        sample-rate (when sample-rate (double sample-rate))
-        f           (fn [^String metric ^double value {:keys [^double sample-rate  #^"[Ljava.lang.String;" tags]}]
-                      (if sample-rate
-                        (.recordHistogramValue client metric value sample-rate tags)
-                        (.recordHistogramValue client metric value tags)))]
-    (f metric value {:sample-rate sample-rate
-                     :tags        tags})))
+  ([^String metric ^Double value]
+   (.recordHistogramValue client metric value -empty-array))
+  ([^String metric ^Double value {:keys [sample-rate tags]}]
+   (let [tags        (str-array tags)
+         sample-rate ^Double sample-rate]
+     (if sample-rate
+       (.recordHistogramValue client metric value sample-rate tags)
+       (.recordHistogramValue client metric value tags)))))
 
 (defmacro time!
-  "Times the body and submits the execution time to metric"
-  [metric opts & body]
+  "Times the body and records the execution time (in msecs) as a histogram.
+
+  Takes opts is a map of :sample-rate and :tags to apply to the histogram
+
+  Examples:
+
+  (statsd/time! [\"my.metric\"]
+    (Thread/sleep 1000))
+
+  (statsd/time! [\"my.metric.with.tags\" {:tags #{\"foo\" :sample-rate 0.3}}]
+    (Thread/sleep 1000))
+
+  "
+  [[metric opts] & body]
   `(let [t0#  (System/currentTimeMillis)
          res# (do ~@body)]
      (histogram ~metric (- (System/currentTimeMillis) t0#) ~opts)

--- a/test/com/unbounce/dogstatsd/core_test.clj
+++ b/test/com/unbounce/dogstatsd/core_test.clj
@@ -44,8 +44,6 @@
     (stest/instrument `sut/gauge)
     (stest/instrument `sut/histogram)
 
-    (sut/setup!)
-
     (stest/check `sut/str-array)
     (stest/check `sut/increment)
     (stest/check `sut/decrement)


### PR DESCRIPTION
1. Remove boxing & allocation where possible
2. Make API consistent (remove keyword args, because it cannot be mixed with
primitive typehints)

Fixes #2 