### PR TITLE
Bump java-dogstastd-client to support env-var based configuration

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -6,7 +6,7 @@
             :comments "Copyright (c) 2018 Unbounce Marketing Solutions Inc."}
   :profiles {:dev {:dependencies [[org.clojure/test.check "0.9.0"]]}}
   :dependencies [[org.clojure/clojure "1.9.0"]
-                 [com.datadoghq/java-dogstatsd-client "2.6.1"]]
+                 [com.datadoghq/java-dogstatsd-client "2.8"]]
   :global-vars {*warn-on-reflection* true}
   :deploy-repositories {"releases" {:url "https://repo.clojars.org" :creds :gpg}}
   )


### PR DESCRIPTION
The underlying library supports using the envvars `DD_AGENT_HOST`, `DD_DOGSTATSD_PORT` and `DD_ENTITY_ID` to configure the client.

The change in this PR removes the "custom" configuration in this library so that we defer all contextual setup to the underlying library. This slightly alters the default behaviour by requiring consumers to set the host explicity (through envvars or the host option).

Closes #15 