### PR TITLE
Add :by option to increment and decrement

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,10 +22,10 @@ Somewhere in your code, you should setup the client:
 ;; You can also configure the host/port by setting the environment variables: DD_AGENT_HOST and DD_DOGSTATSD_PORT
 (statsd/setup! :host "127.0.0.1" :port 8125 :prefix "my.app")
 
-;; Increment or derement a counter
-(statsd/increment "counter")
-(statsd/increment "counter" {:by 2.5 :sample-rate 3.3 :tags ["foo" "bar"]})
-(statsd/decrement "another.counter")
+;; Increment or decrement a counter
+(statsd/increment "counter")           ; increment by 1
+(statsd/increment "counter" {:by 2.5}) ; increment by 2.5
+(statsd/decrement "another.counter")   ; decrement by 1
 
 ;; Records a value at given time
 (statsd/gauge "a.gauge" 10)

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Somewhere in your code, you should setup the client:
 
 ;; Increment or derement a counter
 (statsd/increment "counter")
+(statsd/increment "counter" {:by 2.5 :sample-rate 3.3 :tags ["foo" "bar"]})
 (statsd/decrement "another.counter")
 
 ;; Records a value at given time
@@ -36,7 +37,7 @@ Somewhere in your code, you should setup the client:
 (statsd/time! ["a.timed.body" {}]
   (Thread/sleep 100)
   (Thread/sleep 100))
-  
+
 ;; Time how long it takes with a tag/sample-rate
 (statsd/time! ["my.metric.with.tags" {:tags #{"foo"} :sample-rate 0.3}}]
   (Thread/sleep 1000))
@@ -73,7 +74,7 @@ Usage:
 ;; when sample-rate is set, only 20% of requests will be instrumented
 (def handler (-> (constantly {:status 200})
                  (dogstatsd.ring/wrap-http-metrics {:sample-rate 0.2})))
-                 
+
 ```
 
 

--- a/src/com/unbounce/dogstatsd/core.clj
+++ b/src/com/unbounce/dogstatsd/core.clj
@@ -41,7 +41,7 @@
   (when-not (and client once?)
     (shutdown!)
     (alter-var-root #'client (constantly
-                              (com.timgroup.statsd.NonBlockingStatsDClient.
+                              (NonBlockingStatsDClient.
                                prefix
                                host
                                (or port 0)
@@ -49,21 +49,21 @@
 
 (defn increment
   ([metric]
-   (.incrementCounter client metric -empty-array))
-  ([metric {:keys [tags sample-rate]}]
+   (increment metric {}))
+  ([metric {:keys [tags sample-rate by] :or {by 1.0}}]
    (let [tags (str-array tags)]
      (if sample-rate
-       (.incrementCounter client metric sample-rate tags)
-       (.incrementCounter client metric tags)))))
+       (.count client ^String metric ^double by ^double sample-rate tags)
+       (.count client ^String metric ^double by tags)))))
 
 (defn decrement
   ([metric]
-   (.decrementCounter client metric -empty-array))
-  ([metric {:keys [tags sample-rate]}]
+   (decrement metric {}))
+  ([metric {:keys [tags sample-rate by] :or {by 1.0}}]
    (let [tags (str-array tags)]
      (if sample-rate
-       (.decrementCounter client metric sample-rate tags)
-       (.decrementCounter client metric tags)))))
+       (.count client ^String metric ^double (- by) ^double sample-rate tags)
+       (.count client ^String metric ^double (- by) tags)))))
 
 (defn gauge
   ([^String metric ^Double value]

--- a/test/com/unbounce/dogstatsd/core_test.clj
+++ b/test/com/unbounce/dogstatsd/core_test.clj
@@ -2,11 +2,12 @@
   (:require [clojure.spec.alpha :as s]
             [com.unbounce.dogstatsd.core :as sut]
             [clojure.test :refer [deftest testing is are] :as t]
-            [clojure.spec.test.alpha :as stest]))
+            [clojure.spec.test.alpha :as stest])
+  (:import [com.timgroup.statsd StatsDClient]))
 
 (s/def ::sample-rate number?)
 (s/def ::tags (s/coll-of string?))
-(s/def ::opts (s/keys :opt-un [::tags ::sample-rate]))
+(s/def ::opts (s/keys :opt-un [::tags ::sample-rate ::by]))
 
 (s/fdef sut/str-array
         :args (s/cat :tags ::tags)
@@ -53,15 +54,66 @@
     (are [x y] (= x y)
       nil (sut/increment "asdf")
       nil (sut/increment "asdf" {:tags ["asdf"] :sample-rate 1})
+      nil (sut/increment "asdf" {:by 2})
 
       nil (sut/decrement "asdf")
       nil (sut/decrement "asdf" {:tags ["asdf"] :sample-rate 1})
+      nil (sut/decrement "asdf" {:by 2})
 
       nil (sut/gauge "asdf" 20)
       nil (sut/gauge "asdf" 20 {:tags ["asdf" "asdf"] :sample-rate 1})
 
       nil (sut/histogram "asdf" 20)
       nil (sut/histogram "asdf" 20 {:tags ["asdf" "asdf"] :sample-rate 1}))))
+
+(deftest increment-decrement-test
+  (let [calls (atom [])]
+    (with-redefs [sut/client (reify
+                               StatsDClient
+                               (^void count [self ^String aspect ^double delta ^"[Ljava.lang.String;" tags]
+                                (swap! calls conj {:aspect aspect :delta delta :tags (into [] tags)}))
+                               (^void count [self ^String aspect ^double delta ^double sample-rate ^"[Ljava.lang.String;" tags]
+                                (swap! calls conj {:aspect aspect :delta delta :sample-rate sample-rate :tags (into [] tags)})))]
+      (testing "simple increment"
+        (reset! calls [])
+        (sut/increment "asdf")
+        (is (= [{:aspect "asdf" :delta 1.0 :tags []}]
+               @calls)))
+      (testing "increment by value"
+        (reset! calls [])
+        (sut/increment "asdf" {:by 2})
+        (is (= [{:aspect "asdf" :delta 2.0 :tags []}]
+               @calls)))
+      (testing "increment with sample rate"
+        (reset! calls [])
+        (sut/increment "asdf" {:sample-rate 3.14})
+        (is (= [{:aspect "asdf" :delta 1.0 :sample-rate 3.14 :tags []}]
+               @calls)))
+      (testing "increment with tags"
+        (reset! calls [])
+        (sut/increment "asdf" {:sample-rate 3.14 :tags ["foo" "bar"]})
+        (is (= [{:aspect "asdf" :delta 1.0 :sample-rate 3.14 :tags ["foo" "bar"]}]
+               @calls)))
+      (testing "simple decrement"
+        (reset! calls [])
+        (sut/decrement "asdf")
+        (is (= [{:aspect "asdf" :delta -1.0 :tags []}]
+               @calls)))
+      (testing "decrement by value"
+        (reset! calls [])
+        (sut/decrement "asdf" {:by 2})
+        (is (= [{:aspect "asdf" :delta -2.0 :tags []}]
+               @calls)))
+      (testing "decrement with sample rate"
+        (reset! calls [])
+        (sut/decrement "asdf" {:sample-rate 3.14})
+        (is (= [{:aspect "asdf" :delta -1.0 :sample-rate 3.14 :tags []}]
+               @calls)))
+      (testing "decrement with tags"
+        (reset! calls [])
+        (sut/decrement "asdf" {:sample-rate 3.14 :tags ["foo" "bar"]})
+        (is (= [{:aspect "asdf" :delta -1.0 :sample-rate 3.14 :tags ["foo" "bar"]}]
+               @calls))))))
 
 (deftest time!
   (let [result (atom nil)]


### PR DESCRIPTION
**Why is this change necessary:**

clojure-dogstatsd-client didn't have a way to increment or decrement
by a value different than one.

**How does this change address the issue:**

Add an optional `:by` option to the increment and decrement function.

Implement `increment` and `decrement` by calling
java-dogstatsd-client's `count` method, which supports incrementing or
decrementing by other values than one. (This is the method that
java-dogstatsd-client's `incrementCount` and `decrementCount` call.)

Add unit tests.