### PR TITLE
[fr33m0nk]: Updates DataDog dependency and adds NonBlockingStatsDClientBuilder builder

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject com.unbounce/clojure-dogstatsd-client "0.7.0-SNAPSHOT"
+(defproject com.unbounce/clojure-dogstatsd-client "0.8.0-SNAPSHOT"
   :description "A thin veneer over java-dogstatsd-client"
   :url "https://github.com/unbounce/clojure-dogstatsd-client"
   :license {:name "The MIT License (MIT)"
@@ -6,7 +6,6 @@
             :comments "Copyright (c) 2018 Unbounce Marketing Solutions Inc."}
   :profiles {:dev {:dependencies [[org.clojure/test.check "0.9.0"]]}}
   :dependencies [[org.clojure/clojure "1.9.0"]
-                 [com.datadoghq/java-dogstatsd-client "2.8"]]
+                 [com.datadoghq/java-dogstatsd-client "2.11.0"]]
   :global-vars {*warn-on-reflection* true}
-  :deploy-repositories {"releases" {:url "https://repo.clojars.org" :creds :gpg}}
-  )
+  :deploy-repositories {"releases" {:url "https://repo.clojars.org" :creds :gpg}})

--- a/src/com/unbounce/dogstatsd/core.clj
+++ b/src/com/unbounce/dogstatsd/core.clj
@@ -1,9 +1,9 @@
 (ns com.unbounce.dogstatsd.core
   (:require [clojure.string :as string])
   (:import [com.timgroup.statsd
-            StatsDClient NonBlockingStatsDClient NoOpStatsDClient
+            StatsDClient NoOpStatsDClient
             Event Event$Priority Event$AlertType
-            ServiceCheck ServiceCheck$Status]))
+            ServiceCheck ServiceCheck$Status NonBlockingStatsDClientBuilder]))
 
 ;; In case setup! is not called, this prevents nullpointer exceptions i.e. Unit tests
 (defonce ^:private ^StatsDClient client (NoOpStatsDClient.))
@@ -41,11 +41,12 @@
   (when-not (and client once?)
     (shutdown!)
     (alter-var-root #'client (constantly
-                              (NonBlockingStatsDClient.
-                               prefix
-                               host
-                               (or port 0)
-                               (str-array tags))))))
+                               (-> (NonBlockingStatsDClientBuilder.)
+                                   (.prefix prefix)
+                                   (.hostname host)
+                                   (.port (or port 0))
+                                   (.constantTags (str-array tags))
+                                   (.build))))))
 
 (defn increment
   ([metric]


### PR DESCRIPTION
Updates DataDog library dependency to version 2.11.0 and replaces deprecated [NonBlockingStatsDClient constructor](https://github.com/DataDog/java-dogstatsd-client#configuration) with NonBlockingStatsDClientBuilder builder